### PR TITLE
Add text amplification endpoint for fourfold messaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Codex Operating Guide for GOVIRALL
+
+## Environment & Setup
+- Always provision tooling via `./scripts/setup.sh`. The script creates `.venv`, pins `python3.11` (fallback to `python3`), upgrades `pip`, and installs `requirements.txt`.
+- Activate the environment with `source .venv/bin/activate` before running local commands.
+- Internet access is disabled by default. Do not reach out to external domains without explicit security approval.
+- Secrets belong in `.env.local` (ignored) or a managed secret store. Never paste secrets in prompts or commit history.
+
+## Standard Commands
+| Purpose | Command |
+| --- | --- |
+| Build / serve | `uvicorn main:app --host 0.0.0.0 --port 8000` |
+| Tests | `pytest` (add tests under `tests/`) |
+| Lint | `ruff check .` |
+| Format | `ruff format .` |
+| Typecheck | `mypy .` |
+| Security scan | `bandit -r .` |
+| Schema snapshot | `python -m scripts.schema_check` (create module when schema logic lands) |
+| Model snapshot | `python -m scripts.model_snapshot` (placeholder until modeling module exists) |
+
+> If a command depends on a tool not yet vendored, add it to `requirements-dev.txt` (create as needed) and document the install.
+
+## Python Style Rules
+- Target Python 3.11. Keep modules import-safe and avoid side effects on import.
+- Use type annotations everywhere. Prefer `pydantic` models for request/response bodies.
+- Format with Ruff (PEP 8 compatible, 88 char soft limit). No unused imports or wildcard imports.
+- Never wrap imports in `try/except`. Fail loudly when dependencies are missing.
+- Keep functions under 50 lines. Extract helpers for complex logic.
+
+## Commit & Branch Strategy
+- Branch from `main` using `feature/<slug>` or `fix/<slug>` naming.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`...).
+- Squash commits before merge if history is noisy.
+
+## Review Gates
+1. `pytest`
+2. `ruff check .`
+3. `ruff format --check .`
+4. `mypy .`
+5. `bandit -r .`
+6. Update docs/ADR when architecture changes.
+- Trigger Codex review by commenting `@codex review` on the PR.
+- Human reviewer sign-off is mandatory even when all checks pass; no auto-merge.
+
+## Test Data & Redaction Policy
+- Use synthetic or publicly shareable data in fixtures. No production exports.
+- Strip PII, access tokens, or client identifiers from examples.
+- Delete transient uploads after tests complete. Document fixtures in `/tests/fixtures/README.md` when added.
+
+## Prompt Patterns & Completion Constraints
+- Prompts should outline: **Context**, **Goal**, **Constraints**, **Acceptance tests**.
+- Responses must be concise, technical, and cite sources when referencing repo files or logs.
+- Avoid speculation; prefer actionable TODOs. Highlight security implications explicitly.
+- When uncertain, respond with clarifying questions before proceeding.
+
+## Operational Notes
+- Enable Codex code review in project settings.
+- Rotate API tokens quarterly; record rotations in the security log.
+- Maintain an audit trail in PR descriptions (tests, risk, rollout).

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+PYTHON_BIN="${PYTHON:-python3.11}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+fi
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Error: python3 is required but not found." >&2
+  exit 1
+fi
+
+if [ ! -d "$ROOT_DIR/.venv" ]; then
+  "$PYTHON_BIN" -m venv "$ROOT_DIR/.venv"
+fi
+
+# shellcheck source=/dev/null
+source "$ROOT_DIR/.venv/bin/activate"
+
+python -m pip install --upgrade pip
+python -m pip install -r "$ROOT_DIR/requirements.txt"
+
+echo "Virtual environment ready at $ROOT_DIR/.venv"
+echo "Activate with: source $ROOT_DIR/.venv/bin/activate"

--- a/tests/test_text_amplify.py
+++ b/tests/test_text_amplify.py
@@ -1,0 +1,42 @@
+"""Tests for the text amplification endpoint."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_text_amplify_repeats_four_times() -> None:
+    response = client.post(
+        "/api/text-amplify",
+        json={"text": "Boost   reach now"},
+        headers={"Authorization": "Bearer token"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 4
+    assert payload["items"] == ["Boost reach now"] * 4
+    assert payload["text"] == "Boost reach now Boost reach now Boost reach now Boost reach now"
+
+
+def test_text_amplify_honors_custom_separator() -> None:
+    response = client.post(
+        "/api/text-amplify",
+        json={"text": "Focus", "separator": "|"},
+        headers={"Authorization": "Bearer secure"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["text"] == "Focus|Focus|Focus|Focus"
+    assert payload["items"] == ["Focus"] * 4


### PR DESCRIPTION
## Summary
- add typed request/response models to repeat submitted text exactly four times with optional separators
- expose /api/text-amplify endpoint that reuses bearer auth and deterministic whitespace normalization
- cover the amplifier behavior with FastAPI TestClient regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2517d21648333857bc89eb5d64294