### PR TITLE
Restore README and refine system design documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Operations Guide
+
+## Standard Commands
+- **Install / Setup**: `./scripts/setup.sh`
+- **Format**: `ruff format .`
+- **Lint**: `ruff check .`
+- **Type Check**: `mypy .`
+- **Test**: `pytest`
+- **Security Scan**: `bandit -r .`
+- **License Compliance**: `pip-licenses`
+
+Always run tests after making changes. Lint, type check, and security scans are required before requesting review.
+
+## Style Rules
+- Python must follow PEP 8, prefer `ruff` for enforcement.
+- Keep functions small and pure when possible; avoid side effects in module scope.
+- Markdown should use ATX headings, wrap at ~100 characters, and keep tables GitHub-compatible.
+- Do not add try/except around imports solely to suppress errors.
+
+## Commit & Branching Conventions
+- Use Conventional Commit messages (e.g., `feat:`, `fix:`, `docs:`, `chore:`).
+- Branches should be kebab-case, prefixed with the workstream when relevant (e.g., `feature/api-auth`).
+- Rebase on the default branch before opening a PR; avoid merge commits in feature branches.
+
+## Review Gates
+- Push code only after all mandatory checks (format, lint, type, test, security, license) pass locally.
+- On every PR, comment `@codex review` to trigger automated analysis. Human approval is required before merge.
+
+## Test Data & Redaction
+- Use synthetic or anonymized data in fixtures and examples.
+- Redact or mask any user-generated or sensitive data before committing.
+- Secrets must reside in environment variables or `.env.local`; never commit secrets.
+
+## Prompting & Completion Constraints
+- Prompts should clearly state requirements, expected outputs, and validation steps.
+- Responses must be succinct, technical, and cite sources when referencing repository content.
+- Avoid filler language; focus on actionable guidance and reproducibility.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # Deploy FastAPI on Render
 
-Use this repo as a template to deploy a Python [FastAPI](https://fastapi.tiangolo.com) service on Render.
+Use this repo as a template to deploy a Python
+[FastAPI](https://fastapi.tiangolo.com) service on Render.
 
-See https://render.com/docs/deploy-fastapi or follow the steps below:
+See https://render.com/docs/deploy-fastapi or follow the steps below.
+
+## System Design Documentation
+Detailed architecture, API contracts, and rollout plans for the GOVIRALL platform live in
+[`docs/system_design.md`](docs/system_design.md).
 
 ## Manual Steps
 
-1. You may use this repository directly or [create your own repository from this template](https://github.com/render-examples/fastapi/generate) if you'd like to customize the code.
+1. You may use this repository directly or
+   [create your own repository from this template][fastapi-template]
+   if you'd like to customize the code.
 2. Create a new Web Service on Render.
 3. Specify the URL to your new repository or this repository.
-4. Render will automatically detect that you are deploying a Python service and use `pip` to download the dependencies.
+4. Render will automatically detect that you are deploying a Python service
+   and use `pip` to download the dependencies.
 5. Specify the following as the Start Command.
 
     ```shell
@@ -20,103 +28,83 @@ See https://render.com/docs/deploy-fastapi or follow the steps below:
 
 Or simply click:
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/fastapi)
+[![Deploy to Render][render-badge]][render-deploy]
 
-## Thanks
+## GOVIRALL Product Context
 
-Thanks to [Harish](https://harishgarg.com) for the [inspiration to create a FastAPI quickstart for Render](https://twitter.com/harishkgarg/status/1435084018677010434) and for some sample code!
+You have an existing Viral Score App that estimates how “viral” a post or asset might become
+based on early engagement. For this iteration, the goal is to build on the current product to
+improve prediction accuracy, expand data sources, and expose scores via an API/UI for
+creators and growth teams.
 
-GOVIRAL
-You have an existing Viral Score App that estimates how “viral” a post or asset might become based on early engagement. For this iteration, the goal is to build on the current product to (assumption) improve prediction accuracy, expand data sources, and expose scores via an API/UI for creators and growth teams. 🧠 App Name (Working Title): ViralNow / GoViralNow
+### App Name (Working Title)
+- **ViralNow / GoViralNow**
 
-Tagline: “Predict. Optimize. Go Viral.”
+### Tagline
+- “Predict. Optimize. Go Viral.”
 
-🚀 App Overview
+### App Overview
 
-ViralNow is an AI-powered web and mobile application that analyzes short-form videos, posts, or links (TikTok, YouTube Shorts, Instagram Reels, X, etc.) to generate a 0–100 “Viral Score” — a scientific measure of how likely a piece of content is to go viral.
+ViralNow is an AI-powered web and mobile application that analyzes short-form videos, posts,
+ or links (TikTok, YouTube Shorts, Instagram Reels, X, etc.) to generate a 0–100 “Viral Score” — a
+ scientific measure of how likely a piece of content is to go viral.
 
-The app helps creators, brands, and agencies understand what makes content blow up — and provides specific, data-backed suggestions to improve performance before posting.
+The app helps creators, brands, and agencies understand what makes content blow up — and provides
+specific, data-backed suggestions to improve performance before posting.
 
-Users can upload a video, paste a link, or input text. The system then runs AI analysis (using NLP + CV models) and returns a full viral intelligence report in seconds.
+Users can upload a video, paste a link, or input text. The system then runs AI analysis (using NLP +
+CV models) and returns a full viral intelligence report in seconds.
 
-🧩 Core Features
+### Core Features
+- **Upload or Link Input**
+  - Accepts video, post URL, or raw text (caption/script).
+  - Auto-detects platform (TikTok, YouTube, Instagram, X).
+- **AI Viral Score Engine**
+  - Calculates a 0–100 score + confidence %.
+  - Shows how it performs across each platform.
+  - Uses visual, audio, and text analysis (hook strength, pacing, emotion, clarity,
+    engagement cues).
+- **Why It Works / Why It Won’t**
+  - Bullet summary explaining strengths and weaknesses.
+  - “Missing Elements” section (e.g., “No emotional hook,” “Weak retention curve,”
+    “Text overlay too late”).
+- **Optimization Suggestions**
+  - Auto-generate 5 improved hook lines.
+  - Suggest best posting times, hashtags, and sound types.
+  - Recommend captions, pacing tweaks, or thumbnail ideas.
+- **Competitive Context**
+  - Compare to trending posts in the same niche.
+  - Provide actionable feedback (e.g., “+captions +faster cuts +high contrast”).
+- **Creator Dashboard**
+  - View history of uploads and progress over time.
+  - Track average viral score, niche success rate, and engagement trendlines.
+- **Pro Tier / Academy (Future)**
+  - Access “Viral Blueprint” lessons and case studies.
+  - Sandbox “Prediction Lab” for testing content drafts before posting.
+  - Community leaderboard and gamified growth challenges.
 
-Upload or Link Input
+### Tech Stack (Planned)
+- **Backend**: FastAPI (Python), Redis (rate limits + queues), PostgreSQL (analytics)
+- **Frontend**: React + Tailwind (Web), React Native (Mobile)
+- **AI Models**: OpenAI (text), CLIP / Whisper / Vision Transformers (video + audio)
+- **Deployment**: Docker + Render / Fly.io
+- **Security**: JWT Auth, Argon2 Hashing, API key system
+- **Integrations**: YouTube Data API, TikTok Insights, Google Trends
 
-Accepts video, post URL, or raw text (caption/script).
+### Target Users
+- Content creators — YouTubers, TikTokers, influencers
+- Marketing teams / agencies — running campaigns and audits
+- Educators / coaches — teaching viral content strategy
 
-Auto-detects platform (TikTok, YouTube, Instagram, X).
+### Why It’s Unique
+Unlike typical analytics tools, ViralNow focuses on pre-launch prediction and creative feedback, not
+just post-performance stats. It gives creators the power to simulate the algorithm — before
+publishing.
 
-AI Viral Score Engine
+### Vision
+To become the global standard for viral content prediction — the “credit score” for social media
+success.
 
-Calculates a 0–100 score + confidence %.
-
-Shows how it performs across each platform.
-
-Uses visual, audio, and text analysis (hook strength, pacing, emotion, clarity, engagement cues).
-
-Why It Works / Why It Won’t
-
-Bullet summary explaining strengths and weaknesses.
-
-“Missing Elements” section (e.g., “No emotional hook,” “Weak retention curve,” “Text overlay too late”).
-
-Optimization Suggestions
-
-Auto-generate 5 improved hook lines.
-
-Suggest best posting times, hashtags, and sound types.
-
-Recommend captions, pacing tweaks, or thumbnail ideas.
-
-Competitive Context
-
-Compare to trending posts in the same niche.
-
-“+captions +faster cuts +high contrast” style feedback.
-
-Creator Dashboard
-
-View history of uploads and progress over time.
-
-Track average viral score, niche success rate, and engagement trendlines.
-
-Pro Tier / Academy (Future)
-
-Access “Viral Blueprint” lessons and case studies.
-
-Sandbox “Prediction Lab” for testing content drafts before posting.
-
-Community leaderboard and gamified growth challenges.
-
-🧠 Tech Stack (Planned)
-
-Backend: FastAPI (Python), Redis (rate limits + queues), PostgreSQL (analytics)
-
-Frontend: React + Tailwind (Web), React Native (Mobile)
-
-AI Models: OpenAI (text), CLIP / Whisper / Vision Transformers (video + audio)
-
-Deployment: Docker + Render / Fly.io
-
-Security: JWT Auth, Argon2 Hashing, API Key system
-
-Integrations: YouTube Data API, TikTok Insights, Google Trends
-
-💡 Target Users
-
-Content Creators — YouTubers, TikTokers, Influencers
-
-Marketing Teams / Agencies — running campaigns and audits
-
-Educators / Coaches — teaching viral content strategy
-
-🧩 Why It’s Unique
-
-Unlike typical “analytics” tools, ViralNow focuses on pre-launch prediction and creative feedback, not just post-performance stats. It gives creators the power to simulate the algorithm — before publishing.
-
-🏁 Vision
-
-To become the global standard for viral content prediction — the “credit score” for social media success.
-
-Would you like me to format this next as a Codex manifest / JSON spec (so you can drop it straight into your app.yaml, OpenAI Codex project, or internal repo)? It can include sections like name, description, features, inputs, outputs, and tech_stack.
+[fastapi-template]: https://github.com/render-examples/fastapi/generate
+[render-badge]: https://render.com/images/deploy-to-render-button.svg
+[render-deploy]: https://render.com/deploy?repo=https://github.com/render-examples/fastapi

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -1,0 +1,208 @@
+# System Design Overview
+
+## High-Level Architecture
+```mermaid
+graph LR
+    subgraph Clients
+        W[Web Client]
+        M[Mobile Client]
+    end
+    subgraph Backend
+        APIGW[FastAPI Service]
+        AUTH[Auth Service]
+        AI[AI Inference Worker]
+        QUEUE[Task Queue (Redis)]
+    end
+    subgraph DataStores
+        PG[(PostgreSQL)]
+        OBJ[(Object Storage)]
+    end
+    subgraph ExternalIntegrations
+        OPENAI[(OpenAI API)]
+        SOCIAL[(External Social APIs)]
+    end
+
+    W -->|HTTPS/REST| APIGW
+    M -->|HTTPS/REST| APIGW
+    APIGW --> AUTH
+    AUTH --> APIGW
+    APIGW -->|Persist Metadata| PG
+    APIGW -->|Enqueue Job| QUEUE
+    QUEUE --> AI
+    AI -->|Fetch Prompt & Artifacts| PG
+    AI -->|Inference| OPENAI
+    AI -->|Store Outputs| OBJ
+    AI -->|Update Status| PG
+    APIGW -->|Retrieve Result| PG
+    APIGW -->|Publish| SOCIAL
+```
+
+## Request Flow Summary
+1. Client (web or mobile) sends an authenticated request to FastAPI (for example `/api/analyze`).
+2. FastAPI validates the session via the auth service and persists request metadata in PostgreSQL.
+3. FastAPI enqueues a background job in Redis for AI inference.
+4. The AI worker dequeues the job, assembles prompt/context from PostgreSQL and object storage, then
+   calls the OpenAI API.
+5. The worker stores generated outputs (structured data, media) in PostgreSQL and object storage,
+   updates job status, and emits optional notifications.
+6. Client polls or receives webhook/push with completion data. FastAPI can optionally syndicate
+   results to external social APIs.
+
+## API Surface
+- **POST `/api/auth/login`**
+  - **Auth**: None.
+  - **Request**: `{ "email": string, "password": string }`.
+  - **Response**: `{ "access_token": string, "refresh_token": string, "expires_in": number }`.
+  - **Notes**: Delegates to auth service; tokens are JWTs signed by Auth.
+- **POST `/api/auth/refresh`**
+  - **Auth**: Refresh token.
+  - **Request**: `{ "refresh_token": string }`.
+  - **Response**: `{ "access_token": string, "expires_in": number }`.
+  - **Notes**: Access tokens are short-lived; refresh rotates secrets.
+- **POST `/api/analyze`**
+  - **Auth**: Bearer token.
+  - **Request**:
+    - `source_urls`: string[]
+    - `analysis_type`: "misinformation" | "sentiment"
+    - `options`?: object
+  - **Response**:
+    `{ "job_id": string, "status": "queued" }`.
+  - **Notes**: Persists request, enqueues job.
+- **GET `/api/analyze/{job_id}`**
+  - **Auth**: Bearer token.
+  - **Response**:
+    ```json
+    {
+      "job_id": "string",
+      "status": "queued" | "processing" | "completed" | "failed",
+      "result"?: AnalysisResult
+    }
+    ```
+  - **Notes**: Polling endpoint; surfaces errors.
+- **GET `/api/insights/feed`**
+  - **Auth**: Bearer token.
+  - **Response**: `{ "items": InsightSummary[], "next_cursor"?: string }`.
+  - **Notes**: Fetches curated analysis summaries.
+- **POST `/api/webhooks/social`**
+  - **Auth**: HMAC header.
+  - **Request**: Provider payload.
+  - **Response**: `200 OK`.
+  - **Notes**: Receives callbacks from social APIs; validates HMAC signature.
+
+### AnalysisResult Schema
+```json
+{
+  "summary": "string",
+  "confidence": 0.0,
+  "themes": ["string"],
+  "sources": [
+    {
+      "url": "string",
+      "verdict": "true" | "false" | "mixed",
+      "evidence": "string"
+    }
+  ],
+  "generated_at": "ISO8601 timestamp"
+}
+```
+
+### InsightSummary Schema
+```json
+{
+  "id": "string",
+  "title": "string",
+  "highlights": ["string"],
+  "published_at": "ISO8601 timestamp"
+}
+```
+
+## Core Data Models
+- **User**
+  - `id`: UUID
+  - `email`: string
+  - `hashed_password`: string
+  - `role`: "analyst" | "admin"
+  - `created_at`: timestamp
+  - `last_login_at`: timestamp
+- **Session**
+  - `id`: UUID
+  - `user_id`: UUID
+  - `refresh_token_hash`: string
+  - `expires_at`: timestamp
+  - `created_at`: timestamp
+- **AnalysisJob**
+  - `id`: UUID
+  - `user_id`: UUID
+  - `status`: "queued" | "processing" | "completed" | "failed"
+  - `analysis_type`: string
+  - `payload`: JSONB
+  - `created_at`: timestamp
+  - `started_at`?: timestamp
+  - `completed_at`?: timestamp
+  - `error`?: JSONB
+- **AnalysisResult**
+  - `job_id`: UUID
+  - `summary`: text
+  - `confidence`: numeric
+  - `themes`: text[]
+  - `sources`: JSONB
+  - `generated_at`: timestamp
+- **Insight**
+  - `id`: UUID
+  - `job_id`: UUID
+  - `title`: text
+  - `highlights`: text[]
+  - `published_at`: timestamp
+  - `distribution_targets`: JSONB
+- **AuditEvent**
+  - `id`: UUID
+  - `actor_id`: UUID
+  - `action`: string
+  - `metadata`: JSONB
+  - `created_at`: timestamp
+
+## Integration Contracts
+- **Auth Service**
+  - Endpoint: `/verify`
+  - Response: `{ "sub": UUID, "roles": string[] }`
+  - Notes: FastAPI caches validation results and rotates JWT signing keys.
+- **OpenAI API**
+  - Endpoint: `POST https://api.openai.com/v1/responses`
+  - Model: `gpt-4.1-mini`
+  - Notes: Worker assembles prompts from persisted payloads.
+    Expects streamed completions and retries with exponential backoff on `429` or `5xx` responses.
+- **Redis (Task Queue)**
+  - Stream: `analysis_jobs`
+  - Enqueued payload: `{ job_id, user_id, analysis_type, payload }`
+  - Notes: Workers acknowledge via `analysis_jobs:processed`.
+    Monitoring consumes latency metrics from stream lengths.
+- **PostgreSQL**
+  - Role: Primary metadata store with transactional writes.
+  - Notes: Row-level security enforces per-user access and CDC feeds downstream analytics.
+- **Object Storage**
+  - Role: S3-compatible bucket for large artifacts referenced by URL in PostgreSQL.
+  - Notes: Objects versioned with lifecycle policies for retention.
+- **External Social APIs**
+  - Role: Optional publishing and webhook ingestion.
+  - Notes: Provider SDK integrations require encrypted OAuth tokens.
+    Per-provider shared secrets enforce webhook validation.
+
+## Sequencing & Rollout Plan
+1. **Phase 1 – Backend Foundations**
+   - Stand up PostgreSQL schema, auth integration, and FastAPI skeleton with `/api/auth/*`
+     and `/api/analyze` (queue stubbed).
+   - Implement CI with linting, testing, and security scans.
+     Add observability (structured logging, metrics).
+2. **Phase 2 – AI Pipeline**
+   - Provision Redis queue and AI worker service.
+     Integrate OpenAI API with prompt templates and retry policy.
+   - Add object storage support for artifacts. Define `AnalysisResult` persistence.
+     Expose job polling endpoint.
+3. **Phase 3 – Frontend & Integrations**
+   - Build web/mobile clients for submission and insights feed. Implement push/polling UX.
+   - Integrate social APIs for optional content distribution.
+     Harden webhook security and rate limiting.
+4. **Phase 4 – Hardening & Scale**
+   - Add autoscaling, multi-region failover, and compliance guardrails
+     (audit logging, PII redaction).
+   - Conduct load tests, chaos drills, and finalize rollout checklist for GA.


### PR DESCRIPTION
## Summary
- restore the deployment-focused README content and link to the detailed system design reference
- add a repository operations guide (AGENTS.md) to document workflow and style expectations
- reflow the system design document with structured API, data model, and integration details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ae64bf24833388578fdbeef47841