### PR TITLE
fix: harden setup script and add api tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# GOVIRALL Agent Handbook
+
+These standards apply to the entire repository.
+
+## Environment & Tooling
+- Bootstrap the project with `./scripts/setup.sh`. It pins Python to 3.11.9, creates `.venv`, and installs runtime plus developer dependencies.
+- Always work inside the virtual environment: `source .venv/bin/activate`.
+- Secrets (API keys, tokens) must be loaded from environment variables or `.env.local` files that are git-ignored. Never paste secrets into prompts, code, or logs.
+- Network access is disabled by default. Only enable specific domains when explicitly approved by Legal/SecOps.
+
+## Standard Commands
+Run these from the repository root with the virtual environment activated.
+
+| Purpose | Command |
+| --- | --- |
+| Setup | `./scripts/setup.sh` |
+| Serve (local build) | `uvicorn main:app --reload --host 0.0.0.0 --port 8000` |
+| Tests | `pytest` |
+| Lint | `ruff check .` |
+| Format | `ruff format .` |
+| Type check | `mypy --strict main.py` |
+| Security scan | `bandit -r .` |
+| Dependency audit | `pip-audit` |
+| License compliance | `pip-licenses --format=markdown` |
+
+## Style & Implementation Rules
+- Python code must follow Ruff's default style plus `ruff format` output. Use type hints for all new functions.
+- Favor small, pure functions. Avoid side effects in module scope other than FastAPI app wiring.
+- Validate and sanitize all external inputs. Return structured errors via FastAPI `HTTPException`.
+- Keep docstrings concise and technical.
+- Do not wrap imports in `try/except` blocks.
+
+## Testing Expectations
+- Add unit tests with `pytest` for new logic paths.
+- Prefer `pytest-asyncio` for async endpoints.
+- Ensure mocked external services cover success and failure flows.
+- Tests must not call real third-party APIs. Use fixtures or VCR-style cassettes with redacted data.
+
+## Commit & Branching Conventions
+- Use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, etc.).
+- Branch name format: `<type>/<short-description>` (e.g., `feat/score-normalization`).
+- Rebase onto `main` before opening a PR. No merge commits in feature branches.
+
+## Review Gates
+A pull request is ready for review only when all of the following succeed locally and/or in CI:
+1. `pytest`
+2. `ruff check .`
+3. `ruff format --check .`
+4. `mypy --strict main.py`
+5. `bandit -r .`
+6. `pip-audit`
+7. `pip-licenses --format=plain` (attach output to PR if new dependencies are introduced)
+
+After pushing, comment `@codex review` on the PR to trigger automated analysis. Human review and approval are mandatory prior to merge.
+
+## Data & Redaction Policy
+- Never commit customer, PII, or credential data. Use anonymized, synthetic fixtures.
+- Truncate logs to exclude payloads containing sensitive tokens or user content beyond 2 sentences.
+- Delete temporary artifacts after tests complete.
+
+## Prompting Patterns & Completion Constraints
+- Prompts to Codex/ChatGPT should include: goal, context, constraints, and validation steps.
+- Responses must be succinct, technical, and include citations when referencing repo files or commands.
+- Avoid speculative features without product sign-off. Mark assumptions explicitly.
+- Enforce JSON-only responses when downstream automation requires machine-readable output.
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pytest>=8.3.0
+pytest-asyncio>=0.23.0
+ruff>=0.5.0
+mypy>=1.10.0
+bandit>=1.7.8
+pip-audit>=2.7.3
+pip-licenses>=4.5.1
+types-requests>=2.31.0.10

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repository bootstrap script for developers and CI.
+# Creates a local virtual environment and installs runtime + tooling deps.
+
+PYTHON_VERSION=${PYTHON_VERSION:-3.11.9}
+VENV_DIR=${VENV_DIR:-.venv}
+ALLOW_OFFLINE_FALLBACK=${ALLOW_OFFLINE_FALLBACK:-1}
+
+command -v python3 >/dev/null || { echo "python3 is required" >&2; exit 1; }
+
+# Warn if python version mismatch
+CURRENT_PYTHON=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+if [[ ${CURRENT_PYTHON} != ${PYTHON_VERSION}* ]]; then
+  echo "[setup] Expected python ${PYTHON_VERSION}, found ${CURRENT_PYTHON}." >&2
+fi
+
+create_venv() {
+  local extra=("$@")
+  python3 -m venv "${VENV_DIR}" "${extra[@]}"
+  # shellcheck source=/dev/null
+  source "${VENV_DIR}/bin/activate"
+  python -m ensurepip --upgrade >/dev/null
+}
+
+cleanup() {
+  deactivate >/dev/null 2>&1 || true
+}
+
+create_venv
+trap cleanup EXIT
+
+install_requirements() {
+  local pip_args=()
+  [[ -f requirements.txt ]] && pip_args+=(-r requirements.txt)
+  [[ -f requirements-dev.txt ]] && pip_args+=(-r requirements-dev.txt)
+
+  if [[ ${#pip_args[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  set +e
+  python -m pip install --disable-pip-version-check --no-input "${pip_args[@]}"
+  local status=$?
+  set -e
+  return "${status}"
+}
+
+verify_environment() {
+  local runtime_imports optional_imports
+  runtime_imports=$'fastapi:fastapi\nuvicorn[standard]:uvicorn\npydantic:pydantic\npython-jose[cryptography]:jose\nredis:redis\nhttpx:httpx\nopenai:openai\norjson:orjson\npython-dotenv:dotenv\nrequests:requests'
+  optional_imports=$'pytest:pytest\npytest-asyncio:pytest_asyncio\nruff:ruff\nmypy:mypy\nbandit:bandit\npip-audit:pip_audit\npip-licenses:piplicenses'
+
+  REQUIRED_IMPORTS="${runtime_imports}" OPTIONAL_IMPORTS="${optional_imports}" python - <<'PY'
+import os
+import sys
+from importlib import import_module
+
+
+def inspect(env_key: str, fatal: bool) -> bool:
+    blob = os.environ.get(env_key, "")
+    entries = [line.strip() for line in blob.splitlines() if line.strip()]
+    if not entries:
+        return False
+
+    missing = []
+    for entry in entries:
+        requirement, module = entry.split(":", 1)
+        try:
+            import_module(module)
+        except Exception as exc:  # pragma: no cover - surfaced to user
+            missing.append(f"{requirement} (module '{module}'): {exc}")
+
+    if missing:
+        header = "Missing required packages" if fatal else "Optional developer tools missing"
+        print(f"[setup] {header}:")
+        for item in missing:
+            print(f"  - {item}")
+    return bool(missing) and fatal
+
+
+failed = inspect("REQUIRED_IMPORTS", True)
+if failed:
+    sys.exit(1)
+
+inspect("OPTIONAL_IMPORTS", False)
+PY
+}
+
+USED_FALLBACK=0
+if ! install_requirements; then
+  if [[ ${ALLOW_OFFLINE_FALLBACK} -ne 1 ]]; then
+    echo "[setup] Dependency installation failed. Re-run with network access or set ALLOW_OFFLINE_FALLBACK=1." >&2
+    exit 1
+  fi
+
+  echo "[setup] pip install failed; attempting offline fallback via system site-packages." >&2
+  cleanup
+  rm -rf "${VENV_DIR}"
+  create_venv --system-site-packages
+  USED_FALLBACK=1
+fi
+
+verify_environment
+
+if [[ ${USED_FALLBACK} -eq 1 ]]; then
+  echo "[setup] Environment ready using system site-packages fallback. Activate via: source ${VENV_DIR}/bin/activate" >&2
+  echo "[setup] Optional tools may be unavailable until dependencies can be installed from PyPI." >&2
+else
+  echo "[setup] Environment ready. Activate via: source ${VENV_DIR}/bin/activate"
+fi

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,73 @@
+"""Tests for FastAPI app behaviors and helper utilities."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+main = importlib.import_module("main")
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Provide a FastAPI test client bound to the application."""
+    return TestClient(main.app)
+
+
+def test_health_endpoint(client: TestClient) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_home_endpoint(client: TestClient) -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["docs"] == "/docs"
+    assert payload["health"] == "/health"
+
+
+def test_analyze_mock_response_structure(client: TestClient) -> None:
+    headers = {"Authorization": "Bearer demo-token"}
+    response = client.post("/api/analyze", headers=headers, json={"media": {}})
+    assert response.status_code == 200
+    body: Dict[str, Any] = response.json()
+    expected_keys = {
+        "viral_score",
+        "confidence",
+        "why_it_will_hit",
+        "why_it_wont_hit",
+        "improvement_suggestions",
+        "hook_variations",
+        "hook_variations_tagged",
+        "recommended_hashtags",
+        "best_post_times",
+        "platform_ranking",
+        "next_actions",
+    }
+    assert set(body) == expected_keys
+    assert isinstance(body["improvement_suggestions"], list)
+    assert all(isinstance(item, str) for item in body["improvement_suggestions"])
+
+
+def test_safe_json_parse_allows_strict_json() -> None:
+    payload = {"example": "value"}
+    result = main._safe_json_parse(json.dumps(payload))
+    assert result == payload
+
+
+def test_safe_json_parse_falls_back_to_object_fragment() -> None:
+    fragment = "Some prefix text {\"foo\": 1, \"bar\": 2} trailing garbage"
+    result = main._safe_json_parse(fragment)
+    assert result == {"foo": 1, "bar": 2}


### PR DESCRIPTION
## Summary
- add offline-aware fallback and dependency validation to `scripts/setup.sh`
- tighten FastAPI type hints and JSON parsing safety in `main.py`
- introduce pytest coverage for health, home, analyze, and JSON parsing helpers

## Testing
- `./scripts/setup.sh`
- `source .venv/bin/activate && pytest`
- `source .venv/bin/activate && ruff check .`
- `source .venv/bin/activate && mypy --strict main.py`


------
https://chatgpt.com/codex/tasks/task_e_68e25108dbfc8333a2075ab2a5e1daf0